### PR TITLE
feat: terraform code for worker cloud function and firestore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
 # Terraform
-env.tfvars
-.terraform/
-terraform.tfstate*
+**/.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+*.tfvars.json
+
+# Build
+**/dist/

--- a/google/.terraform.lock.hcl
+++ b/google/.terraform.lock.hcl
@@ -1,0 +1,39 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.2.0"
+  hashes = [
+    "h1:2K5LQkuWRS2YN1/YoNaHn9MAzjuTX8Gaqy6i8Mbfv8Y=",
+    "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
+    "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
+    "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
+    "zh:55c0d7ddddbd0a46d57c51fcfa9b91f14eed081a45101dbfc7fd9d2278aa1403",
+    "zh:73a5dd68379119167934c48afa1101b09abad2deb436cd5c446733e705869d6b",
+    "zh:841fc4ac6dc3479981330974d44ad2341deada8a5ff9e3b1b4510702dfbdbed9",
+    "zh:91be62c9b41edb137f7f835491183628d484e9d6efa82fcb75cfa538c92791c5",
+    "zh:acd5f442bd88d67eb948b18dc2ed421c6c3faee62d3a12200e442bfff0aa7d8b",
+    "zh:ad5720da5524641ad718a565694821be5f61f68f1c3c5d2cfa24426b8e774bef",
+    "zh:e63f12ea938520b3f83634fc29da28d92eed5cfbc5cc8ca08281a6a9c36cca65",
+    "zh:f6542918faa115df46474a36aabb4c3899650bea036b5f8a5e296be6f8f25767",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.0.0"
+  constraints = "~> 4.0.0"
+  hashes = [
+    "h1:9Wx5zZikv9lvMzt119deXAnzyNsEcqtA4ifE8MYN0e8=",
+    "zh:48fbf905a5c1658b042c7edb0183e9a25dc04257cd5e6d4d870b33a0bc70eda4",
+    "zh:5f7a1579e23f0d187cc9062ec54f30d7336252705d4e0dd9dbd799cebd83429b",
+    "zh:63bb8f094eec5cecf1acbe7026c0ba31126670282dbcfce01477aec6c134a3bd",
+    "zh:7654b20e5dc0ed595f084039e8fd49ff70c11e2ed7b9fcc9c6169f3217845adb",
+    "zh:7bc37430171b2148b2bb835dc2eff967714d2ac515e73784b66c2ddda6d260fa",
+    "zh:84212e750b3a319055ee0dc43ef40a1096fea6793af8d87aecc330ead4e8e9c9",
+    "zh:ac53b6cd95fc024b96dba46e204bbc4963e744c7017f11d454ba49a4a8355ee3",
+    "zh:cc6a4989874fc7a1d3b82f8be761867c85472b37c5656a81cee8385330a5afa2",
+    "zh:d1ffc766f855995b6117f7f40ec02e2404a8474630dbcc38b8355519af1a47f5",
+    "zh:e68183a7c0f1efec3e36931ca06d31060218a9d44379aad5269e9d6fc6e6f47f",
+    "zh:e7c0dbfae422f8ae663c3462d549ac69287038fc880bfad5c58790b82bfde620",
+  ]
+}

--- a/google/.terraform.lock.hcl
+++ b/google/.terraform.lock.hcl
@@ -37,3 +37,21 @@ provider "registry.terraform.io/hashicorp/google" {
     "zh:e7c0dbfae422f8ae663c3462d549ac69287038fc880bfad5c58790b82bfde620",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.1.0"
+  hashes = [
+    "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
+    "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
+    "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
+    "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
+    "zh:7011332745ea061e517fe1319bd6c75054a314155cb2c1199a5b01fe1889a7e2",
+    "zh:738ed82858317ccc246691c8b85995bc125ac3b4143043219bd0437adc56c992",
+    "zh:7dbe52fac7bb21227acd7529b487511c91f4107db9cc4414f50d04ffc3cab427",
+    "zh:a3a9251fb15f93e4cfc1789800fc2d7414bbc18944ad4c5c98f466e6477c42bc",
+    "zh:a543ec1a3a8c20635cf374110bd2f87c07374cf2c50617eee2c669b3ceeeaa9f",
+    "zh:d9ab41d556a48bd7059f0810cf020500635bfc696c9fc3adab5ea8915c1d886b",
+    "zh:d9e13427a7d011dbd654e591b0337e6074eef8c3b9bb11b2e39eaaf257044fd7",
+    "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
+  ]
+}

--- a/google/env.tfvars.example
+++ b/google/env.tfvars.example
@@ -1,0 +1,2 @@
+project_id  = "my-project-1234"
+cloudfunction_source_dir  = "path/to/source"

--- a/google/main.tf
+++ b/google/main.tf
@@ -25,3 +25,10 @@ module "cloudfunction" {
   name        = local.cloudfunction_name
   source_dir  = var.cloudfunction_source_dir
 }
+
+module "firestore" {
+  source = "./modules/firestore"
+
+  project_id  = var.project_id
+  location_id = local.region
+}

--- a/google/main.tf
+++ b/google/main.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_providers {
+    google = {
+      version = "~> 4.0.0"
+    }
+  }
+}
+
+locals {
+  region                    = "europe-west3"
+  zone                      = "europe-west3-c"
+  cloudfunction_entry_point = "Digest"
+  cloudfunction_name        = "digest-stats"
+  firestore_collection      = "runs"
+}
+
+module "cloudfunction" {
+  source = "./modules/cloudfunction"
+
+  project_id  = var.project_id
+  region      = local.region
+  zone        = local.zone
+  entry_point = local.cloudfunction_entry_point
+  collection  = local.firestore_collection
+  name        = local.cloudfunction_name
+  source_dir  = var.cloudfunction_source_dir
+}

--- a/google/modules/cloudfunction/README.md
+++ b/google/modules/cloudfunction/README.md
@@ -1,0 +1,14 @@
+# Module `google/cloudfunction`
+
+This module offers infrastructure code defining a Google Cloud Function triggered by Cloud Firestore `create` event type.
+
+It creates the following resources:
+
+- a Cloud Function tiggered by `cloud.firestore/eventTypes/document.create`
+- a Cloud Storage bucket for uploading an archive of the function's source code
+- a Service Account specific to the Cloud Function with `roles/cloudfunctions.invoker` and `roles/datastore.user` roles
+
+It also enables the following APIs on the projet if they are not already:
+
+- Cloud Functions API
+- Cloud Build API

--- a/google/modules/cloudfunction/archive.tf
+++ b/google/modules/cloudfunction/archive.tf
@@ -1,0 +1,18 @@
+data "archive_file" "source" {
+  type        = "zip"
+  source_dir  = var.source_dir
+  output_path = "${path.root}/dist/function.zip"
+  excludes    = fileset(path.root, "**")
+}
+
+resource "google_storage_bucket" "bucket" {
+  name     = "${var.name}-function"
+  location = "EUROPE-WEST3"
+}
+
+resource "google_storage_bucket_object" "archive" {
+  # Append file MD5 to force bucket to be recreated when the content changes
+  name   = "function-${data.archive_file.source.output_md5}.zip"
+  bucket = google_storage_bucket.bucket.name
+  source = data.archive_file.source.output_path
+}

--- a/google/modules/cloudfunction/main.tf
+++ b/google/modules/cloudfunction/main.tf
@@ -1,0 +1,24 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+}
+
+resource "google_cloudfunctions_function" "function" {
+  project     = var.project_id
+  region      = var.region
+  name        = var.name
+  description = "${var.name} is a Cloud Function triggered by a Firestore create event to extract, compute and store statistics of a run."
+
+  runtime             = "go116"
+  available_memory_mb = 256
+  timeout             = 30
+  entry_point         = var.entry_point
+  event_trigger {
+    event_type = "providers/cloud.firestore/eventTypes/document.create"
+    resource   = "projects/${var.project_id}/databases/(default)/documents/${var.collection}/{id}"
+  }
+  source_archive_bucket = google_storage_bucket.bucket.name
+  source_archive_object = google_storage_bucket_object.archive.name
+  max_instances         = 10
+}

--- a/google/modules/cloudfunction/service.tf
+++ b/google/modules/cloudfunction/service.tf
@@ -1,0 +1,17 @@
+# Cloud Functions requires Cloud Functions API
+resource "google_project_service" "cloudfunctions_api" {
+  project = var.project_id
+  service = "cloudfunctions.googleapis.com"
+
+  disable_dependent_services = true
+  disable_on_destroy         = false
+}
+
+# Cloud Functions requires Cloud Build API
+resource "google_project_service" "cloudbuild_api" {
+  project = var.project_id
+  service = "cloudbuild.googleapis.com"
+
+  disable_dependent_services = true
+  disable_on_destroy         = false
+}

--- a/google/modules/cloudfunction/service_account.tf
+++ b/google/modules/cloudfunction/service_account.tf
@@ -1,0 +1,20 @@
+resource "google_service_account" "service_account" {
+  account_id   = "cloud-function-invoker"
+  display_name = "Cloud Function invoker service account"
+}
+
+resource "google_project_iam_member" "invoker" {
+  count = length(local.roles) # Repeat for each role
+
+  project = google_cloudfunctions_function.function.project
+
+  role   = element(local.roles, count.index) # Bind each role
+  member = "serviceAccount:${google_service_account.service_account.email}"
+}
+
+locals {
+  roles = [
+    "roles/cloudfunctions.invoker",
+    "roles/datastore.user"
+  ]
+}

--- a/google/modules/cloudfunction/variables.tf
+++ b/google/modules/cloudfunction/variables.tf
@@ -1,0 +1,34 @@
+variable "project_id" {
+  description = "The ID of the project in which to provision resources"
+  type        = string
+}
+
+variable "region" {
+  description = "The region where to provision resources"
+  type        = string
+}
+
+variable "zone" {
+  description = "The location for zonal resources"
+  type        = string
+}
+
+variable "name" {
+  description = "Name of the cloud function"
+  type        = string
+}
+
+variable "entry_point" {
+  description = "Name of the function that will be executed on trigger"
+  type        = string
+}
+
+variable "collection" {
+  description = "The Cloud Firestore collection that will trigger the function when documents are created in"
+  type        = string
+}
+
+variable "source_dir" {
+  description = "Path to the directory containing the source code. Will be archived and uploaded."
+  type        = string
+}

--- a/google/modules/firestore/README.md
+++ b/google/modules/firestore/README.md
@@ -1,0 +1,9 @@
+# Module `google/firestore`
+
+This module offers infrastructure code enabling Google Cloud Firestore on the project.
+
+If Firestore is already enabled on the project, import the existing resource by running the following command from the root module directory:
+
+```sh
+terraform import module.firestore.google_app_engine_application.app YOUR_PROJECT_ID
+```

--- a/google/modules/firestore/main.tf
+++ b/google/modules/firestore/main.tf
@@ -1,0 +1,9 @@
+provider "google" {
+  project = var.project_id
+}
+
+resource "google_app_engine_application" "app" {
+  project       = var.project_id
+  location_id   = var.location_id
+  database_type = "CLOUD_FIRESTORE"
+}

--- a/google/modules/firestore/variables.tf
+++ b/google/modules/firestore/variables.tf
@@ -1,0 +1,9 @@
+variable "project_id" {
+  description = "The ID of the project in which to provision resources"
+  type        = string
+}
+
+variable "location_id" {
+  description = "The location to serve the app from"
+  type        = string
+}

--- a/google/variables.tf
+++ b/google/variables.tf
@@ -1,0 +1,7 @@
+variable "project_id" {
+  type = string
+}
+
+variable "cloudfunction_source_dir" {
+  type = string
+}


### PR DESCRIPTION
<!-- IMPORTANT: Don't forget to link the issue(s) once the PR created! -->

## Description

This PR adds infrastructure code to define a Firestore app and a Cloud Function triggered by document creation inside a collection of this Firestore.

This infrastructure is used to deploy `benchttp/worker` and to offer the Firestore app where `benchttp/server` writes its data.
